### PR TITLE
Implement mobile homepage UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,47 @@
-import { EmergencyButton } from '@/components/EmergencyButton'
 import { ScenarioCard } from '@/components/ScenarioCard'
+import { FooterNav } from '@/components/FooterNav'
+import type { ReactNode } from 'react'
+
+interface Scenario {
+  id: string
+  title: string
+  icon: ReactNode
+}
 
 export default function Home() {
-  const scenarios = [] // fetch from Supabase later
+  const scenarios: Scenario[] = [
+    { id: 'overdose', title: 'A Drug Overdose', icon: '💊' },
+    { id: 'aggressive', title: 'Someone Is Acting Aggressively', icon: '😡' },
+    { id: 'mental-health', title: 'A Mental Health Crisis', icon: '😔' },
+    { id: 'supplies', title: 'Need Harm Reduction Supplies', icon: '🧰' },
+  ]
   return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Care Connect</h1>
-      <div className="grid gap-4 sm:grid-cols-2">
+    <main className="p-4 pb-32 space-y-6">
+      <h1 className="text-center text-lg font-semibold mt-2">
+        Tell us what you are witnessing, and we help you connect
+      </h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {scenarios.map((s) => (
           <ScenarioCard key={s.id} scenario={s} />
         ))}
       </div>
-      <EmergencyButton />
+      <div className="text-center space-y-3">
+        <p className="font-medium">If Inside NRCH Premises</p>
+        <a
+          href="tel:0394289725"
+          className="block mx-auto w-full max-w-xs bg-green-600 text-white py-3 rounded-full shadow"
+        >
+          Call 03 9428 9725
+        </a>
+        <p>Dial 000 in case of emergency</p>
+        <a
+          href="tel:000"
+          className="block mx-auto w-full max-w-xs border border-red-600 text-red-600 py-3 rounded-full"
+        >
+          Call 000
+        </a>
+      </div>
+      <FooterNav />
     </main>
   )
 }

--- a/src/components/FooterNav.tsx
+++ b/src/components/FooterNav.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import { LayoutGrid, Info, BookOpen, Heart } from 'lucide-react'
+
+export function FooterNav() {
+  const items = [
+    { href: '/', label: 'Scenarios', icon: LayoutGrid, active: true },
+    { href: '/about', label: 'About', icon: Info },
+    { href: '/learn', label: 'Learn', icon: BookOpen },
+    { href: '/support', label: 'Support', icon: Heart },
+  ]
+  return (
+    <>
+      <nav className="fixed bottom-10 inset-x-0 mx-4 bg-white shadow rounded-full flex justify-around items-center py-2 text-xs">
+        {items.map((item) => (
+          <Link
+            key={item.label}
+            href={item.href}
+            className={`flex flex-col items-center gap-1 ${
+              item.active ? 'text-blue-700' : 'text-gray-500'
+            }`}
+          >
+            <item.icon size={18} />
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+      <div className="fixed bottom-0 inset-x-0 bg-black text-white text-center text-xs py-1">
+        www.careconnectnrch.com.au
+      </div>
+    </>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,11 @@
-import Link from 'next/link'
-
 export function Header() {
   return (
-    <header className="p-4 flex justify-between items-center bg-primary text-primary-foreground">
-      <Link href="/" className="font-bold">Care Connect</Link>
-      <nav className="flex gap-4">
-        <Link href="/">Home</Link>
-        <Link href="/emergency">Emergency</Link>
-      </nav>
+    <header className="bg-[#1f2c3e] text-white border-b-4 border-green-300 px-4 py-3 flex items-center justify-between">
+      <div>
+        <h1 className="font-bold text-lg leading-none">CareConnect</h1>
+        <p className="text-sm">Care for yourself. Care for others.</p>
+      </div>
+      <button className="text-sm font-semibold uppercase">EN</button>
     </header>
   )
 }

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -1,18 +1,29 @@
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import { ChevronRight } from 'lucide-react'
+import { ReactNode } from 'react'
 
 interface Scenario {
   id: string
   title: string
+  icon: ReactNode
 }
 
 export function ScenarioCard({ scenario }: { scenario: Scenario }) {
   return (
-    <motion.div whileHover={{ scale: 1.02 }} className="border p-4 rounded-lg">
-      <h2 className="text-lg font-semibold mb-2">{scenario.title}</h2>
-      <Link href={`/scenarios/${scenario.id}`} className="text-primary underline">
-        View
-      </Link>
-    </motion.div>
+    <Link href={`/scenarios/${scenario.id}`}> 
+      <motion.div
+        whileHover={{ scale: 1.03 }}
+        className="bg-white rounded-lg shadow flex items-center justify-between p-4"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-2xl" aria-hidden="true">
+            {scenario.icon}
+          </span>
+          <span className="font-medium">{scenario.title}</span>
+        </div>
+        <ChevronRight className="text-gray-400" size={20} />
+      </motion.div>
+    </Link>
   )
 }


### PR DESCRIPTION
## Summary
- style header with tagline and language toggle
- update ScenarioCard design
- add mobile footer navigation
- build basic homepage layout with scenario cards and emergency links

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784b7ef0f883208bd504958e559403