### PR TITLE
Add CTA route and button component

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --color-primary: #005FA3;
+  --color-accent: #79B435;
+}

--- a/src/app/scenario/[scenarioId]/[subScenarioId]/cta/page.tsx
+++ b/src/app/scenario/[scenarioId]/[subScenarioId]/cta/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from 'next/navigation'
+import { scenarios } from '@/constants/scenarios'
+import { CTAButton } from '@/components/CTAButton'
+
+interface Params {
+  scenarioId: string
+  subScenarioId: string
+}
+
+export default function CTAPage({ params }: { params: Params }) {
+  const scenario = scenarios[params.scenarioId]
+  const sub = scenario?.subScenarios[params.subScenarioId]
+
+  if (!scenario || !sub) notFound()
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">{sub.title}</h1>
+      <p>{sub.description}</p>
+      <CTAButton {...sub.cta} fullWidth />
+    </main>
+  )
+}

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { cn } from '@/lib/utils'
+import type { ReactNode } from 'react'
+import { designTokens } from '@/constants/designTokens'
+
+export interface CTAButtonProps {
+  label: string
+  variant?: 'primary' | 'secondary' | 'danger' | 'link'
+  icon?: ReactNode
+  href: string
+  fullWidth?: boolean
+}
+
+const baseStyles = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition'
+
+const variants: Record<Required<CTAButtonProps>['variant'], string> = {
+  primary: `bg-[${designTokens.colors.primary}] text-white hover:bg-[${designTokens.colors.primary}]/90`,
+  secondary: `bg-[${designTokens.colors.accent}] text-white hover:bg-[${designTokens.colors.accent}]/90`,
+  danger: 'bg-red-600 text-white hover:bg-red-700',
+  link: `underline text-[${designTokens.colors.primary}] hover:text-[${designTokens.colors.primary}]/80`
+}
+
+export function CTAButton({ label, variant = 'primary', icon, href, fullWidth }: CTAButtonProps) {
+  const className = cn(baseStyles, variants[variant], fullWidth && 'w-full', 'px-4 py-3 shadow', 'rounded',)
+
+  // Determine if the link is external (e.g. tel: or http)
+  const isExternal = href.startsWith('http') || href.startsWith('tel:') || href.startsWith('mailto:')
+
+  /*
+    Pseudocode:
+    if isExternal:
+      render <a href> so the browser performs a normal navigation or phone call
+    else:
+      use <Link> for internal application routes
+    end
+  */
+
+  const content = (
+    <motion.span whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }} className="flex items-center gap-2">
+      {icon && <span aria-hidden="true">{icon}</span>}
+      {label}
+    </motion.span>
+  )
+
+  if (isExternal) {
+    return (
+      <a href={href} className={className} style={{ transition: designTokens.transitions.default }}>
+        {content}
+      </a>
+    )
+  }
+
+  return (
+    <Link href={href} className={className} style={{ transition: designTokens.transitions.default }}>
+      {content}
+    </Link>
+  )
+}

--- a/src/constants/designTokens.ts
+++ b/src/constants/designTokens.ts
@@ -1,0 +1,34 @@
+export const designTokens = {
+  colors: {
+    primary: '#005FA3',
+    accent: '#79B435'
+  },
+  fontSizes: {
+    sm: '0.875rem',
+    base: '1rem',
+    lg: '1.125rem',
+    xl: '1.25rem'
+  },
+  radii: {
+    sm: '0.25rem',
+    md: '0.375rem',
+    lg: '0.5rem',
+    full: '9999px'
+  },
+  shadows: {
+    sm: '0 1px 2px rgba(0,0,0,0.05)',
+    md: '0 4px 6px rgba(0,0,0,0.1)'
+  },
+  spacing: {
+    1: '0.25rem',
+    2: '0.5rem',
+    3: '0.75rem',
+    4: '1rem',
+    5: '1.25rem',
+    6: '1.5rem'
+  },
+  transitions: {
+    default: 'all 0.2s ease-in-out'
+  }
+} as const
+export type DesignTokens = typeof designTokens

--- a/src/constants/scenarios.ts
+++ b/src/constants/scenarios.ts
@@ -1,0 +1,57 @@
+import { Phone, ArrowRight } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+export type CTAButtonVariant = 'primary' | 'secondary' | 'danger' | 'link'
+
+export interface CTADetails {
+  label: string
+  href: string
+  variant: CTAButtonVariant
+  icon?: ReactNode
+}
+
+export interface SubScenario {
+  id: string
+  title: string
+  description: string
+  cta: CTADetails
+}
+
+export interface Scenario {
+  id: string
+  title: string
+  subScenarios: Record<string, SubScenario>
+}
+
+// Simple content used by the demo screens
+export const scenarios: Record<string, Scenario> = {
+  overdose: {
+    id: 'overdose',
+    title: 'Drug Overdose',
+    subScenarios: {
+      witness: {
+        id: 'witness',
+        title: 'Witnessing an overdose',
+        description:
+          'If someone has overdosed you should immediately call emergency services.',
+        cta: {
+          label: 'Call 000',
+          href: 'tel:000',
+          variant: 'danger',
+          icon: <Phone size={16} />
+        }
+      },
+      selfcare: {
+        id: 'selfcare',
+        title: 'Need self care advice',
+        description: 'View helpful resources to support the person.',
+        cta: {
+          label: 'View self care tips',
+          href: '/self-care',
+          variant: 'primary',
+          icon: <ArrowRight size={16} />
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create design tokens and scenario constants
- build CTAButton with variants and Framer Motion effects
- add `/scenario/[scenarioId]/[subScenarioId]/cta` route
- expose style tokens in global CSS

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden; registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68784cec70e083209925ba0ababb907b