### PR TITLE
Add splash screen

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { ScenarioCard } from '@/components/ScenarioCard'
 import { FooterNav } from '@/components/FooterNav'
-import type { ReactNode } from 'react'
+import SplashScreen from '@/components/SplashScreen'
+import { useEffect, useState, type ReactNode } from 'react'
 
 interface Scenario {
   id: string
@@ -15,6 +16,17 @@ export default function Home() {
     { id: 'mental-health', title: 'A Mental Health Crisis', icon: '😔' },
     { id: 'supplies', title: 'Need Harm Reduction Supplies', icon: '🧰' },
   ]
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setLoading(false), 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (loading) {
+    return <SplashScreen />
+  }
+
   return (
     <main className="p-4 pb-32 space-y-6">
       <h1 className="text-center text-lg font-semibold mt-2">

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,0 +1,8 @@
+export default function SplashScreen() {
+  return (
+    <div className="fixed inset-0 flex flex-col items-center justify-center bg-white text-gray-900 z-50">
+      <h1 className="text-3xl font-bold">Care Connect</h1>
+      <p className="absolute bottom-6 text-sm">Developed by North Richmond Community Health</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `SplashScreen` component
- show splash screen on app load for 2 seconds

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784e51c3d48320ace6f90258cc7d9a