### PR TITLE
Refactor scenario constants and client components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,14 @@
+"use client"
+
 import { ScenarioCard } from '@/components/ScenarioCard'
 import { FooterNav } from '@/components/FooterNav'
 import SplashScreen from '@/components/SplashScreen'
-import { useEffect, useState, type ReactNode } from 'react'
-
-interface Scenario {
-  id: string
-  title: string
-  icon: ReactNode
-}
+import { useEffect, useState } from 'react'
+import { scenarios } from '@/constants/scenarios'
+import type { Scenario } from '@/types/scenario'
 
 export default function Home() {
-  const scenarios: Scenario[] = [
-    { id: 'overdose', title: 'A Drug Overdose', icon: '💊' },
-    { id: 'aggressive', title: 'Someone Is Acting Aggressively', icon: '😡' },
-    { id: 'mental-health', title: 'A Mental Health Crisis', icon: '😔' },
-    { id: 'supplies', title: 'Need Harm Reduction Supplies', icon: '🧰' },
-  ]
+  const list: Scenario[] = Object.values(scenarios)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -33,7 +26,7 @@ export default function Home() {
         Tell us what you are witnessing, and we help you connect
       </h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {scenarios.map((s) => (
+        {list.map((s) => (
           <ScenarioCard key={s.id} scenario={s} />
         ))}
       </div>

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -3,14 +3,14 @@
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
-import type { ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
 import { designTokens } from '@/constants/designTokens'
 
 export interface CTAButtonProps {
   label: string
-  variant?: 'primary' | 'secondary' | 'danger' | 'link'
-  icon?: ReactNode
   href: string
+  variant?: 'primary' | 'danger' | 'secondary' | 'link'
+  icon?: LucideIcon
   fullWidth?: boolean
 }
 
@@ -38,9 +38,10 @@ export function CTAButton({ label, variant = 'primary', icon, href, fullWidth }:
     end
   */
 
+  const Icon = icon
   const content = (
     <motion.span whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }} className="flex items-center gap-2">
-      {icon && <span aria-hidden="true">{icon}</span>}
+      {Icon && <Icon size={16} aria-hidden="true" />}
       {label}
     </motion.span>
   )

--- a/src/components/EmergencyButton.tsx
+++ b/src/components/EmergencyButton.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { Phone } from 'lucide-react'

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -1,12 +1,15 @@
+'use client'
+
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
-import { ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { createElement } from 'react'
 
 interface Scenario {
   id: string
   title: string
-  icon: ReactNode
+  icon: LucideIcon
 }
 
 export function ScenarioCard({ scenario }: { scenario: Scenario }) {
@@ -18,7 +21,7 @@ export function ScenarioCard({ scenario }: { scenario: Scenario }) {
       >
         <div className="flex items-center gap-3">
           <span className="text-2xl" aria-hidden="true">
-            {scenario.icon}
+            {createElement(scenario.icon)}
           </span>
           <span className="font-medium">{scenario.title}</span>
         </div>

--- a/src/constants/scenarios.ts
+++ b/src/constants/scenarios.ts
@@ -1,56 +1,62 @@
-import { Phone, ArrowRight } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { Phone, ArrowRight, Pill, AlertTriangle, Brain, Package } from 'lucide-react'
+import type { Scenario } from '@/types/scenario'
 
-export type CTAButtonVariant = 'primary' | 'secondary' | 'danger' | 'link'
-
-export interface CTADetails {
-  label: string
-  href: string
-  variant: CTAButtonVariant
-  icon?: ReactNode
-}
-
-export interface SubScenario {
-  id: string
-  title: string
-  description: string
-  cta: CTADetails
-}
-
-export interface Scenario {
-  id: string
-  title: string
-  subScenarios: Record<string, SubScenario>
-}
-
-// Simple content used by the demo screens
 export const scenarios: Record<string, Scenario> = {
   overdose: {
     id: 'overdose',
-    title: 'Drug Overdose',
+    title: 'A Drug Overdose',
+    icon: Pill,
     subScenarios: {
       witness: {
         id: 'witness',
         title: 'Witnessing an overdose',
-        description:
-          'If someone has overdosed you should immediately call emergency services.',
-        cta: {
-          label: 'Call 000',
-          href: 'tel:000',
-          variant: 'danger',
-          icon: <Phone size={16} />
-        }
+        description: 'If someone has overdosed you should immediately call emergency services.',
+        cta: { label: 'Call 000', href: 'tel:000', variant: 'danger', icon: Phone }
       },
       selfcare: {
         id: 'selfcare',
         title: 'Need self care advice',
         description: 'View helpful resources to support the person.',
-        cta: {
-          label: 'View self care tips',
-          href: '/self-care',
-          variant: 'primary',
-          icon: <ArrowRight size={16} />
-        }
+        cta: { label: 'View self care tips', href: '/self-care', variant: 'primary', icon: ArrowRight }
+      }
+    }
+  },
+  aggressive: {
+    id: 'aggressive',
+    title: 'Someone Is Acting Aggressively',
+    icon: AlertTriangle,
+    subScenarios: {
+      default: {
+        id: 'default',
+        title: 'Aggressive behaviour',
+        description: 'Stay safe and consider calling for help.',
+        cta: { label: 'Call 000', href: 'tel:000', variant: 'danger', icon: Phone }
+      }
+    }
+  },
+  'mental-health': {
+    id: 'mental-health',
+    title: 'A Mental Health Crisis',
+    icon: Brain,
+    subScenarios: {
+      default: {
+        id: 'default',
+        title: 'Need mental health support',
+        description: 'Connect with mental health services.',
+        cta: { label: 'Call support', href: 'tel:000', variant: 'primary', icon: Phone }
+      }
+    }
+  },
+  supplies: {
+    id: 'supplies',
+    title: 'Need Harm Reduction Supplies',
+    icon: Package,
+    subScenarios: {
+      default: {
+        id: 'default',
+        title: 'Find supplies',
+        description: 'Locate nearby harm reduction supplies.',
+        cta: { label: 'View locations', href: '/locations', variant: 'primary', icon: ArrowRight }
       }
     }
   }

--- a/src/types/scenario.ts
+++ b/src/types/scenario.ts
@@ -1,0 +1,24 @@
+export type CTAButtonVariant = "primary" | "secondary" | "danger" | "link";
+
+import type { LucideIcon } from "lucide-react";
+
+export interface CTADetails {
+  label: string;
+  href: string;
+  variant: CTAButtonVariant;
+  icon?: LucideIcon;
+}
+
+export interface SubScenario {
+  id: string;
+  title: string;
+  description: string;
+  cta: CTADetails;
+}
+
+export interface Scenario {
+  id: string;
+  title: string;
+  icon: LucideIcon;
+  subScenarios: Record<string, SubScenario>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,12 +14,16 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@/components/*": ["src/components/*"],
+      "@/lib/*": ["src/lib/*"],
+      "@/constants/*": ["src/constants/*"],
+      "@/types/*": ["src/types/*"]
     },
-    "types": ["node"]
+    "types": ["react", "react-dom", "node"]
   },
   "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- centralize scenario data with icon references
- add client directive to interactive components
- create typed scenario definitions
- update CTA button to render icon components
- expose path aliases and react JSX in tsconfig

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785e6fe85c8320a7966b7962430690