### PR TITLE
Integrate offline CSV data with dynamic pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,23 @@
-"use client"
-
 import { ScenarioCard } from '@/components/ScenarioCard'
 import { FooterNav } from '@/components/FooterNav'
-import SplashScreen from '@/components/SplashScreen'
-import { useEffect, useState } from 'react'
-import { scenarios } from '@/constants/scenarios'
+import { getScenarioData } from '@/lib/loadCSV'
+import { scenarios as iconScenarios } from '@/constants/scenarios'
 import type { Scenario } from '@/types/scenario'
 
 export default function Home() {
-  const list: Scenario[] = Object.values(scenarios)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const timer = setTimeout(() => setLoading(false), 2000)
-    return () => clearTimeout(timer)
-  }, [])
-
-  if (loading) {
-    return <SplashScreen />
-  }
+  const data = getScenarioData()
+  const unique = Array.from(
+    data.reduce((map, row) => {
+      if (!map.has(row.scenario_id)) map.set(row.scenario_id, row)
+      return map
+    }, new Map<string, typeof data[number]>())
+  ).map(([_, row]) => row)
+  const list: Scenario[] = unique.map((row) => ({
+    id: row.scenario_id,
+    title: row.scenario_title,
+    icon: iconScenarios[row.scenario_id]?.icon ?? iconScenarios['overdose'].icon,
+    subScenarios: {}
+  }))
 
   return (
     <main className="p-4 pb-32 space-y-6">

--- a/src/app/scenario/[scenarioId]/[subScenarioId]/cta/self-care/page.tsx
+++ b/src/app/scenario/[scenarioId]/[subScenarioId]/cta/self-care/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation'
-import { CTAButton } from '@/components/CTAButton'
 import { getScenarioData } from '@/lib/loadCSV'
 import Link from 'next/link'
 
@@ -8,22 +7,20 @@ interface Params {
   subScenarioId: string
 }
 
-export default function CTAPage({ params }: { params: Params }) {
+export default function SelfCarePage({ params }: { params: Params }) {
   const row = getScenarioData().find(
     (r) =>
       r.scenario_id === params.scenarioId &&
       r.subscenario_id === params.subScenarioId
   )
-
   if (!row) notFound()
 
   return (
     <main className="p-4 space-y-4">
-      <h1 className="text-xl font-semibold">{row.subscenario_title}</h1>
-      <p>{row.body_text}</p>
-      <CTAButton label={row.cta_text} href={row.cta_link} fullWidth />
-      <Link href={`./self-care`} className="text-blue-600 underline">
-        Need self care tips?
+      <h1 className="text-xl font-semibold">Self Care Tips</h1>
+      <p>{row.selfcare_text}</p>
+      <Link href=".." className="text-blue-600 underline">
+        Back
       </Link>
     </main>
   )

--- a/src/app/scenario/[scenarioId]/[subScenarioId]/page.tsx
+++ b/src/app/scenario/[scenarioId]/[subScenarioId]/page.tsx
@@ -1,30 +1,27 @@
-import { notFound } from 'next/navigation'
 import { CTAButton } from '@/components/CTAButton'
-import { getScenarioData } from '@/lib/loadCSV'
+import { notFound } from 'next/navigation'
 import Link from 'next/link'
+import { getScenarioData } from '@/lib/loadCSV'
 
 interface Params {
   scenarioId: string
-  subScenarioId: string
+  subscenarioId: string
 }
 
-export default function CTAPage({ params }: { params: Params }) {
+export default function SubScenarioPage({ params }: { params: Params }) {
   const row = getScenarioData().find(
     (r) =>
       r.scenario_id === params.scenarioId &&
-      r.subscenario_id === params.subScenarioId
+      r.subscenario_id === params.subscenarioId
   )
-
   if (!row) notFound()
 
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">{row.subscenario_title}</h1>
       <p>{row.body_text}</p>
-      <CTAButton label={row.cta_text} href={row.cta_link} fullWidth />
-      <Link href={`./self-care`} className="text-blue-600 underline">
-        Need self care tips?
-      </Link>
+      <CTAButton label={row.cta_text} href={`/scenario/${row.scenario_id}/${row.subscenario_id}/cta`} fullWidth />
+      <Link href={`/scenario/${row.scenario_id}`}>Back</Link>
     </main>
   )
 }

--- a/src/app/scenario/[scenarioId]/page.tsx
+++ b/src/app/scenario/[scenarioId]/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getScenarioData } from '@/lib/loadCSV'
+
+interface Params { scenarioId: string }
+
+export default function ScenarioPage({ params }: { params: Params }) {
+  const data = getScenarioData().filter(
+    (r) => r.scenario_id === params.scenarioId
+  )
+  if (data.length === 0) notFound()
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">{data[0].scenario_title}</h1>
+      <ul className="space-y-2">
+        {data.map((sub) => (
+          <li key={sub.subscenario_id}>
+            <Link
+              href={`/scenario/${sub.scenario_id}/${sub.subscenario_id}`}
+              className="block p-4 rounded shadow bg-white"
+            >
+              {sub.subscenario_title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/src/assets/data-folder.csv
+++ b/src/assets/data-folder.csv
@@ -1,5 +1,0 @@
-scenario_id,scenario_title,subscenario_id,subscenario_title,body_text,cta_text,cta_link,selfcare_text
-overdose,Suspected Drug Overdose,in-public,Someone collapsed in public,"If someone appears unconscious, unresponsive, or turning blue, follow the steps below.",Call 000,tel:000,Breathe — you acted quickly. Help is on the way.
-overdose,Suspected Drug Overdose,at-home,Someone overdosing at home,"If someone you know has overdosed at home, it’s critical to stay calm and act fast.",Call emergency services,tel:000,You stayed strong when it mattered. Take a moment to look after yourself.
-needles,Used Needles & Syringes,public-park,Found a needle in public park,You found used injecting equipment. It’s okay to feel uneasy. Here's what to do next.,Call Richmond Housing,tel:0394289725,You did the right thing. Thank you for protecting your community.
-aggression,Challenging Behaviours,on-street,Someone acting aggressively,It’s normal to feel unsafe around aggressive behavior. Distance yourself first.,Call 000,tel:000,Prioritizing your safety is brave. Well done.

--- a/src/assets/data/scenarios.csv
+++ b/src/assets/data/scenarios.csv
@@ -1,0 +1,5 @@
+scenario_id,scenario_title,subscenario_id,subscenario_title,body_text,cta_text,cta_link,selfcare_text
+overdose,Suspected Drug Overdose,in-public,Someone collapsed in public,"If someone appears unconscious, unresponsive, or turning blue, follow the steps below.",Call 000,tel:000,Breathe — you acted quickly. Help is on the way.
+overdose,Suspected Drug Overdose,at-home,Someone overdosing at home,"If someone you know has overdosed at home, it’s critical to stay calm and act fast.",Call emergency services,tel:000,You stayed strong when it mattered. Take a moment to look after yourself.
+needles,Used Needles & Syringes,public-park,Found a needle in public park,"You found used injecting equipment. It’s okay to feel uneasy. Here's what to do next.",Call Richmond Housing,tel:0394289725,You did the right thing. Thank you for protecting your community.
+aggression,Challenging Behaviours,on-street,Someone acting aggressively,"It’s normal to feel unsafe around aggressive behavior. Distance yourself first.",Call 000,tel:000,Prioritizing your safety is brave. Well done.

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -14,7 +14,7 @@ interface Scenario {
 
 export function ScenarioCard({ scenario }: { scenario: Scenario }) {
   return (
-    <Link href={`/scenarios/${scenario.id}`}> 
+    <Link href={`/scenario/${scenario.id}`}> 
       <motion.div
         whileHover={{ scale: 1.03 }}
         className="bg-white rounded-lg shadow flex items-center justify-between p-4"

--- a/src/lib/loadCSV.ts
+++ b/src/lib/loadCSV.ts
@@ -1,0 +1,58 @@
+import fs from 'fs'
+import path from 'path'
+
+export interface OfflineSubScenario {
+  scenario_id: string
+  scenario_title: string
+  subscenario_id: string
+  subscenario_title: string
+  body_text: string
+  cta_text: string
+  cta_link: string
+  selfcare_text: string
+}
+
+let cache: OfflineSubScenario[] | null = null
+
+function parseCSV(content: string): OfflineSubScenario[] {
+  const rows: OfflineSubScenario[] = []
+  const lines = content.trim().split(/\r?\n/)
+  const headers = lines.shift()?.split(',') ?? []
+  const quoteRegex = /^"|"$/g
+  for (const line of lines) {
+    const cols: string[] = []
+    let current = ''
+    let inQuotes = false
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i]
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          current += '"'
+          i++
+        } else {
+          inQuotes = !inQuotes
+        }
+      } else if (char === ',' && !inQuotes) {
+        cols.push(current)
+        current = ''
+      } else {
+        current += char
+      }
+    }
+    cols.push(current)
+    const obj: any = {}
+    headers.forEach((h, idx) => {
+      obj[h.trim()] = cols[idx]?.replace(quoteRegex, '') ?? ''
+    })
+    rows.push(obj as OfflineSubScenario)
+  }
+  return rows
+}
+
+export function getScenarioData(): OfflineSubScenario[] {
+  if (cache) return cache
+  const filePath = path.join(process.cwd(), 'src/assets/data/scenarios.csv')
+  const content = fs.readFileSync(filePath, 'utf8')
+  cache = parseCSV(content)
+  return cache
+}


### PR DESCRIPTION
## Summary
- parse scenario data from `/src/assets/data/scenarios.csv`
- expose typed helper `getScenarioData` for caching CSV data
- link scenario cards to new `/scenario` routes
- build dynamic scenario and sub-scenario pages
- show CTA and self‑care pages based on CSV rows

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_687865d8712c8320a0721671962b312a