### PR TITLE
Switch scenarios to CSV data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 import { ScenarioCard } from '@/components/ScenarioCard'
 import { FooterNav } from '@/components/FooterNav'
-import { getScenarioData } from '@/lib/loadCSV'
+import { loadScenariosFromCSV } from '@/lib/loadCSV'
 import { scenarios as iconScenarios } from '@/constants/scenarios'
 import type { Scenario } from '@/types/scenario'
 
 export default function Home() {
-  const data = getScenarioData()
+  const data = loadScenariosFromCSV()
   const unique = Array.from(
     data.reduce((map, row) => {
       if (!map.has(row.scenario_id)) map.set(row.scenario_id, row)

--- a/src/app/scenario/[scenarioId]/[subScenarioId]/cta/page.tsx
+++ b/src/app/scenario/[scenarioId]/[subScenarioId]/cta/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 import { CTAButton } from '@/components/CTAButton'
-import { getScenarioData } from '@/lib/loadCSV'
+import { loadScenariosFromCSV } from '@/lib/loadCSV'
 import Link from 'next/link'
 
 interface Params {
@@ -9,7 +9,7 @@ interface Params {
 }
 
 export default function CTAPage({ params }: { params: Params }) {
-  const row = getScenarioData().find(
+  const row = loadScenariosFromCSV().find(
     (r) =>
       r.scenario_id === params.scenarioId &&
       r.subscenario_id === params.subScenarioId

--- a/src/app/scenario/[scenarioId]/[subScenarioId]/cta/self-care/page.tsx
+++ b/src/app/scenario/[scenarioId]/[subScenarioId]/cta/self-care/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation'
-import { getScenarioData } from '@/lib/loadCSV'
+import { loadScenariosFromCSV } from '@/lib/loadCSV'
 import Link from 'next/link'
 
 interface Params {
@@ -8,7 +8,7 @@ interface Params {
 }
 
 export default function SelfCarePage({ params }: { params: Params }) {
-  const row = getScenarioData().find(
+  const row = loadScenariosFromCSV().find(
     (r) =>
       r.scenario_id === params.scenarioId &&
       r.subscenario_id === params.subScenarioId

--- a/src/app/scenario/[scenarioId]/[subScenarioId]/page.tsx
+++ b/src/app/scenario/[scenarioId]/[subScenarioId]/page.tsx
@@ -1,7 +1,7 @@
 import { CTAButton } from '@/components/CTAButton'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
-import { getScenarioData } from '@/lib/loadCSV'
+import { loadScenariosFromCSV } from '@/lib/loadCSV'
 
 interface Params {
   scenarioId: string
@@ -9,7 +9,7 @@ interface Params {
 }
 
 export default function SubScenarioPage({ params }: { params: Params }) {
-  const row = getScenarioData().find(
+  const row = loadScenariosFromCSV().find(
     (r) =>
       r.scenario_id === params.scenarioId &&
       r.subscenario_id === params.subscenarioId

--- a/src/app/scenario/[scenarioId]/page.tsx
+++ b/src/app/scenario/[scenarioId]/page.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { getScenarioData } from '@/lib/loadCSV'
+import { loadScenariosFromCSV } from '@/lib/loadCSV'
 
 interface Params { scenarioId: string }
 
 export default function ScenarioPage({ params }: { params: Params }) {
-  const data = getScenarioData().filter(
+  const data = loadScenariosFromCSV().filter(
     (r) => r.scenario_id === params.scenarioId
   )
   if (data.length === 0) notFound()

--- a/src/app/scenarios/[id]/page.tsx
+++ b/src/app/scenarios/[id]/page.tsx
@@ -1,23 +1,28 @@
-import { EmergencyButton } from '@/components/EmergencyButton'
-import { supabase } from '@/lib/supabaseClient'
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { loadScenariosFromCSV } from '@/lib/loadCSV'
 
 interface Params { id: string }
 
-export default async function Scenario({ params }: { params: Params }) {
-  const { data } = await supabase
-    .from('scenarios')
-    .select('*')
-    .eq('id', params.id)
-    .single()
-
-  if (!data) notFound()
+export default function Scenario({ params }: { params: Params }) {
+  const data = loadScenariosFromCSV().filter((r) => r.scenario_id === params.id)
+  if (data.length === 0) notFound()
 
   return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold mb-2">{data.title}</h1>
-      <p className="mb-4">{data.body}</p>
-      <EmergencyButton />
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">{data[0].scenario_title}</h1>
+      <ul className="space-y-2">
+        {data.map((sub) => (
+          <li key={sub.subscenario_id}>
+            <Link
+              href={`/scenarios/${sub.scenario_id}/${sub.subscenario_id}`}
+              className="block p-4 rounded shadow bg-white"
+            >
+              {sub.subscenario_title}
+            </Link>
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js'
-
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const key = process.env.NEXT_PUBLIC_SUPABASE_KEY!
-
-export const supabase = createClient(url, key)


### PR DESCRIPTION
## Summary
- remove Supabase client and queries
- parse scenario data from CSV at build time
- update scenario pages to read from CSV

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787e08d0a88320842cc4a55cbafad3