### PR TITLE
Apply design tokens and modular CSS

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import '../styles/tokens.css';
+
 :root {
-  --color-primary: #005FA3;
   --color-accent: #79B435;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,14 +33,16 @@ export default function Home() {
         <p className="font-medium">If Inside NRCH Premises</p>
         <a
           href="tel:0394289725"
-          className="block mx-auto w-full max-w-xs bg-green-600 text-white py-3 rounded-full shadow"
+          aria-label="Call 03 9428 9725"
+          className="block mx-auto w-full max-w-xs bg-[var(--color-accent)] text-white py-3 rounded-full shadow"
         >
           Call 03 9428 9725
         </a>
         <p>Dial 000 in case of emergency</p>
         <a
           href="tel:000"
-          className="block mx-auto w-full max-w-xs border border-red-600 text-red-600 py-3 rounded-full"
+          aria-label="Call 000"
+          className="block mx-auto w-full max-w-xs border border-[var(--color-danger)] text-[var(--color-danger)] py-3 rounded-full"
         >
           Call 000
         </a>

--- a/src/components/CTAButton.module.css
+++ b/src/components/CTAButton.module.css
@@ -1,0 +1,45 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  border-radius: var(--radius-default);
+  padding: var(--spacing-sm) var(--spacing-md);
+  transition: all 0.2s ease;
+}
+.fullWidth {
+  width: 100%;
+}
+.primary {
+  background-color: var(--color-primary);
+  color: #fff;
+}
+.primary:hover {
+  opacity: 0.9;
+}
+.danger {
+  background-color: var(--color-danger);
+  color: #fff;
+}
+.danger:hover {
+  opacity: 0.9;
+}
+.secondary {
+  background-color: var(--color-accent);
+  color: #fff;
+}
+.secondary:hover {
+  opacity: 0.9;
+}
+.link {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+.link:hover {
+  opacity: 0.8;
+}
+.iconLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
-import { designTokens } from '@/constants/designTokens'
+import styles from './CTAButton.module.css'
 
 export interface CTAButtonProps {
   label: string
@@ -13,17 +13,19 @@ export interface CTAButtonProps {
   fullWidth?: boolean
 }
 
-const baseStyles = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition'
-
 const variants: Record<Required<CTAButtonProps>['variant'], string> = {
-  primary: `bg-[${designTokens.colors.primary}] text-white hover:bg-[${designTokens.colors.primary}]/90`,
-  secondary: `bg-[${designTokens.colors.accent}] text-white hover:bg-[${designTokens.colors.accent}]/90`,
-  danger: 'bg-red-600 text-white hover:bg-red-700',
-  link: `underline text-[${designTokens.colors.primary}] hover:text-[${designTokens.colors.primary}]/80`
+  primary: styles.primary,
+  secondary: styles.secondary,
+  danger: styles.danger,
+  link: styles.link
 }
 
 export function CTAButton({ label, variant = 'primary', icon, href, fullWidth }: CTAButtonProps) {
-  const className = cn(baseStyles, variants[variant], fullWidth && 'w-full', 'px-4 py-3 shadow', 'rounded',)
+  const className = cn(
+    styles.button,
+    variants[variant],
+    fullWidth && styles.fullWidth,
+  )
 
   // Determine if the link is external (e.g. tel: or http)
   const isExternal = href.startsWith('http') || href.startsWith('tel:') || href.startsWith('mailto:')
@@ -38,7 +40,7 @@ export function CTAButton({ label, variant = 'primary', icon, href, fullWidth }:
   */
 
   const content = (
-    <motion.span whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }} className="flex items-center gap-2">
+    <motion.span whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }} className={styles.iconLabel}>
       {icon}
       {label}
     </motion.span>
@@ -46,14 +48,14 @@ export function CTAButton({ label, variant = 'primary', icon, href, fullWidth }:
 
   if (isExternal) {
     return (
-      <a href={href} className={className} style={{ transition: designTokens.transitions.default }}>
+      <a href={href} className={className} aria-label={label}>
         {content}
       </a>
     )
   }
 
   return (
-    <Link href={href} className={className} style={{ transition: designTokens.transitions.default }}>
+    <Link href={href} className={className} aria-label={label}>
       {content}
     </Link>
   )

--- a/src/components/EmergencyButton.module.css
+++ b/src/components/EmergencyButton.module.css
@@ -1,0 +1,20 @@
+.container {
+  position: fixed;
+  bottom: var(--spacing-md);
+  right: var(--spacing-md);
+}
+.button {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  background-color: var(--color-danger);
+  color: #fff;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: 9999px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  transition: all 0.2s ease;
+  text-decoration: none;
+}
+.button:hover {
+  opacity: 0.9;
+}

--- a/src/components/EmergencyButton.tsx
+++ b/src/components/EmergencyButton.tsx
@@ -3,18 +3,16 @@
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { Phone } from 'lucide-react'
+import styles from './EmergencyButton.module.css'
 
 export function EmergencyButton() {
   return (
     <motion.div
-      className="fixed bottom-4 right-4"
+      className={styles.container}
       initial={{ scale: 0 }}
       animate={{ scale: 1 }}
     >
-      <Link
-        href="/emergency"
-        className="flex items-center gap-2 bg-red-600 text-white px-4 py-2 rounded-full shadow-lg"
-      >
+      <Link href="/emergency" className={styles.button} aria-label="Emergency">
         <Phone size={16} /> Emergency
       </Link>
     </motion.div>

--- a/src/components/FooterNav.module.css
+++ b/src/components/FooterNav.module.css
@@ -1,0 +1,37 @@
+.navContainer {
+  position: fixed;
+  bottom: var(--spacing-lg);
+  left: 0;
+  right: 0;
+  margin: 0 var(--spacing-md);
+  background-color: #fff;
+  border-radius: var(--radius-default);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  padding: var(--spacing-sm) 0;
+  font-size: 0.75rem;
+}
+.link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+.linkInactive {
+  color: gray;
+}
+.footerText {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #000;
+  color: #fff;
+  text-align: center;
+  font-size: 0.75rem;
+  padding: var(--spacing-sm) 0;
+}

--- a/src/components/FooterNav.tsx
+++ b/src/components/FooterNav.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { LayoutGrid, Info, BookOpen, Heart } from 'lucide-react'
+import styles from './FooterNav.module.css'
 
 export function FooterNav() {
   const items = [
@@ -10,23 +11,20 @@ export function FooterNav() {
   ]
   return (
     <>
-      <nav role="navigation" className="fixed bottom-10 inset-x-0 mx-4 bg-white shadow rounded-full flex justify-around items-center py-2 text-xs">
+      <nav role="navigation" className={styles.navContainer}>
         {items.map((item) => (
-          <Link
-            key={item.label}
-            href={item.href}
-            className={`flex flex-col items-center gap-1 ${
-              item.active ? 'text-blue-700' : 'text-gray-500'
-            }`}
-          >
+            <Link
+              key={item.label}
+              href={item.href}
+              aria-label={item.label}
+              className={item.active ? styles.link : `${styles.link} ${styles.linkInactive}`}
+            >
             <item.icon size={18} />
             {item.label}
           </Link>
         ))}
       </nav> as JSX.Element
-      <div className="fixed bottom-0 inset-x-0 bg-black text-white text-center text-xs py-1">
-        www.careconnectnrch.com.au
-      </div>
+      <div className={styles.footerText}>www.careconnectnrch.com.au</div>
     </>
   )
 }

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,0 +1,25 @@
+.header {
+  background-color: #1f2c3e;
+  color: #fff;
+  border-bottom: 4px solid var(--color-accent);
+  padding: var(--spacing-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.title {
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1;
+}
+.subtitle {
+  font-size: 0.875rem;
+}
+.langButton {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: none;
+  border: none;
+  color: inherit;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,13 @@
+import styles from './Header.module.css'
+
 export function Header() {
   return (
-    <header className="bg-[#1f2c3e] text-white border-b-4 border-green-300 px-4 py-3 flex items-center justify-between">
+    <header className={styles.header}>
       <div>
-        <h1 className="font-bold text-lg leading-none">CareConnect</h1>
-        <p className="text-sm">Care for yourself. Care for others.</p>
+        <h1 className={styles.title}>CareConnect</h1>
+        <p className={styles.subtitle}>Care for yourself. Care for others.</p>
       </div>
-      <button className="text-sm font-semibold uppercase">EN</button>
+      <button className={styles.langButton} aria-label="Change language">EN</button>
     </header>
   )
 }

--- a/src/components/ScenarioCard.module.css
+++ b/src/components/ScenarioCard.module.css
@@ -1,0 +1,27 @@
+.card {
+  background-color: #fff;
+  border-radius: var(--radius-default);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md);
+  transition: transform 0.2s ease;
+}
+.card:hover {
+  transform: scale(1.03);
+}
+.content {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+.icon {
+  font-size: 1.5rem;
+}
+.title {
+  font-weight: 500;
+}
+.chevron {
+  color: gray;
+}

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
 import type { ReactNode } from 'react'
+import styles from './ScenarioCard.module.css'
 
 interface Scenario {
   id: string
@@ -13,16 +14,15 @@ interface Scenario {
 
 export function ScenarioCard({ scenario }: { scenario: Scenario }) {
   return (
-    <Link href={`/scenario/${scenario.id}`}> 
-      <motion.div
-        whileHover={{ scale: 1.03 }}
-        className="bg-white rounded-lg shadow flex items-center justify-between p-4"
-      >
-        <div className="flex items-center gap-3">
-          <span className="text-2xl" aria-hidden="true">{scenario.icon}</span>
-          <span className="font-medium">{scenario.title}</span>
+    <Link href={`/scenario/${scenario.id}`} aria-label={scenario.title}>
+      <motion.div whileHover={{ scale: 1.03 }} className={styles.card}>
+        <div className={styles.content}>
+          <span className={styles.icon} aria-hidden="true">
+            {scenario.icon}
+          </span>
+          <span className={styles.title}>{scenario.title}</span>
         </div>
-        <ChevronRight className="text-gray-400" size={20} />
+        <ChevronRight className={styles.chevron} size={20} />
       </motion.div>
     </Link>
   )

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,10 @@
+:root {
+  --color-primary: #005FA3;
+  --color-danger: #dc2626;
+  --radius-default: 0.375rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --font-heading: 'Inter', sans-serif;
+  --font-body: 'Inter', sans-serif;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,18 @@ const config: Config = {
     extend: {
       fontFamily: {
         sans: ['var(--font-inter)', ...fontFamily.sans]
+      },
+      colors: {
+        primary: 'var(--color-primary)',
+        danger: 'var(--color-danger)'
+      },
+      borderRadius: {
+        DEFAULT: 'var(--radius-default)'
+      },
+      spacing: {
+        sm: 'var(--spacing-sm)',
+        md: 'var(--spacing-md)',
+        lg: 'var(--spacing-lg)'
       }
     }
   },


### PR DESCRIPTION
## Summary
- add CSS design tokens
- convert CTAButton, EmergencyButton, FooterNav, Header and ScenarioCard to CSS modules
- use tokens in Tailwind config and home page links

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68788acc09108320887c90995d1a8485